### PR TITLE
Displ constr/lab/ex 2 hotfixes/person class

### DIFF
--- a/Domain/Entities/Person/abstraction.h
+++ b/Domain/Entities/Person/abstraction.h
@@ -7,26 +7,26 @@
 
 template<typename TValue>
 class APerson
-	: public IPerson<TValue>
+    : public IPerson<TValue>
 {
 protected:
-	TValue* _name = nullptr;
+    TValue* _name = nullptr;
 public:
-	APerson()
-		: _name(new TValue(DEFAULT_EMPTY_STRING))
-	{ CREATE_INFO("APerson <- Default constructor: called;"); }
-	APerson(TValue name)
-		: _name(new TValue(name))
-	{ CREATE_INFO("APerson <- Constructor: called;"); }
-	APerson(APerson&& other) noexcept
-		: _name(other.getName())
-	{ CREATE_INFO("Person <- Move constructor: called;"); other.setName(nullptr); }
+    APerson()
+        : _name(new TValue(DEFAULT_EMPTY_STRING))
+    { CREATE_INFO("APerson <- Default constructor: called;"); }
+    APerson(TValue name)
+        : _name(new TValue(name))
+    { CREATE_INFO("APerson <- Constructor: called;"); }
+    APerson(APerson&& other) noexcept
+        : _name(new TValue(other.getName()))
+    { CREATE_INFO("APerson <- Move constructor: called;"); other.setName(DEFAULT_EMPTY_STRING); }
 
-	virtual ~APerson()
-	{ CREATE_INFO("APerson <- Destructor: called;"); if (_name != nullptr) { delete _name; _name = nullptr; } }
+    virtual ~APerson()
+    { CREATE_INFO("APerson <- Destructor: called;"); if (_name != nullptr) { delete _name; _name = nullptr; } }
 
-	TValue getName() const override { INFO("APerson -> Method getName: called;"); if (_name != nullptr) { return *_name; } return DEFAULT_EMPTY_STRING; }
-	void setName(const TValue& value) override { INFO("APerson -> Method setName: called;"); if (_name != nullptr) { delete _name; } this->_name = new TValue(value); }
+    TValue getName() const override { INFO("APerson -> Method getName: called;"); if (_name != nullptr) { return *_name; } return DEFAULT_EMPTY_STRING; }
+    void setName(const TValue& value) override { INFO("APerson -> Method setName: called;"); if (_name != nullptr) { delete _name; } this->_name = new TValue(value); }
 };
 
 #endif

--- a/Domain/Entities/Person/abstraction.h
+++ b/Domain/Entities/Person/abstraction.h
@@ -18,6 +18,9 @@ public:
 	APerson(TValue name)
 		: _name(new TValue(name))
 	{ CREATE_INFO("APerson <- Constructor: called;"); }
+	APerson(APerson&& other) noexcept
+		: _name(other.getName())
+	{ CREATE_INFO("Person <- Move constructor: called;"); other.setName(nullptr); }
 
 	virtual ~APerson()
 	{ CREATE_INFO("APerson <- Destructor: called;"); if (_name != nullptr) { delete _name; _name = nullptr; } }

--- a/Domain/Entities/Person/person.h
+++ b/Domain/Entities/Person/person.h
@@ -14,8 +14,11 @@ public:
 		: APerson(name)
 	{ CREATE_INFO("Person <- Constructor: called;"); }
 	Person(Person&& other) noexcept
-		: APerson(other.getName())
-	{ CREATE_INFO("Person <- Move constructor: called;"); other.setName(nullptr); }
+		: APerson(move(other))
+	{ CREATE_INFO("Person <- Move constructor: called;"); }
+	Person(APerson&& other) noexcept
+		: APerson(move(other))
+	{ CREATE_INFO("Person <- Move constructor: called;"); }
 
 	virtual ~Person() override
 	{ CREATE_INFO("Person <- Destructor: called;"); }

--- a/Domain/Entities/Person/person.h
+++ b/Domain/Entities/Person/person.h
@@ -3,21 +3,22 @@
 
 #include "abstraction.h"
 
+template<typename TReturn>
 class Person
-	: public APerson<string>
+	: public APerson<TReturn>
 {
 public:
 	Person()
 		: APerson()
 	{ CREATE_INFO("Person <- Default constructor: called;"); }
-	Person(string name)
-		: APerson(name)
+	Person(TReturn name)
+		: APerson<TReturn>(name)
 	{ CREATE_INFO("Person <- Constructor: called;"); }
 	Person(Person&& other) noexcept
-		: APerson(move(other))
+		: APerson<TReturn>(move(other))
 	{ CREATE_INFO("Person <- Move constructor: called;"); }
-	Person(APerson&& other) noexcept
-		: APerson(move(other))
+	Person(APerson<TReturn>&& other) noexcept
+		: APerson<TReturn>(move(other))
 	{ CREATE_INFO("Person <- Move constructor: called;"); }
 
 	virtual ~Person() override

--- a/Presentation/View/Intro/intro.cpp
+++ b/Presentation/View/Intro/intro.cpp
@@ -3,5 +3,13 @@
 
 void View::Intro0()
 {
-	APerson* person0 = 
+	APerson<string>* person0 = new Person<string>("Joe");
+	APerson<string>* person1 = new Person<string>(move(*person0)); delete person0;
+	
+	cout << person1->getName() << endl;
+
+	person1->setName("Hello world!");
+	cout << person1->getName() << endl;
+	
+	delete person1;
 }

--- a/Presentation/View/Intro/intro.cpp
+++ b/Presentation/View/Intro/intro.cpp
@@ -3,15 +3,5 @@
 
 void View::Intro0()
 {
-	Person* person0 = new Person("Joe");
-	Person* person1 = move(person0);
-	Person* person2 = new Person("Joe");
-
-	person1->setName("Jhon");
-
-	cout << person1->getName() << endl
-		<< person2->getName() << endl;
-
-	delete person1;
-	delete person2;
+	APerson* person0 = 
 }


### PR DESCRIPTION
This pull request includes several changes to improve the handling of move semantics and template usage in the `Person` class and its related files. The most important changes include adding a move constructor to `APerson`, templating the `Person` class, and updating the `Intro0` function to use the new template structure.

Enhancements to move semantics:

* [`Domain/Entities/Person/abstraction.h`](diffhunk://#diff-ad9fa0390e8bd6b407349aff94d74e27fa7bc7888b418e55b999b3377fa62468R21-R23): Added a move constructor to the `APerson` class to properly handle move operations and set the moved-from object's name to a default empty string.

Template usage improvements:

* [`Domain/Entities/Person/person.h`](diffhunk://#diff-e83a2ed6463cf261a16b7be4dcdaae8f43225804f91b279d498bd247926c212eR6-R22): Templated the `Person` class to allow for different return types and updated constructors and move constructors to use the new template parameter.

Code updates to reflect new template structure:

* [`Presentation/View/Intro/intro.cpp`](diffhunk://#diff-34a2313046212dafcb739993f98a34f7c8cf3bc55de542ce1f0a0bc9ef0034abL6-L16): Updated the `Intro0` function to use `APerson<string>` and the new move constructor, ensuring proper memory management by deleting the moved-from object.